### PR TITLE
Remove aether parent pom dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,6 @@ object Dependencies {
     "org.scala-sbt" %% "librarymanagement-core" % libraryManagementVersion,
     "org.scala-sbt" %% "librarymanagement-ivy" % libraryManagementVersion,
     "org.apache.maven" % "maven-aether-provider" % mvnVersion,
-    "org.eclipse.aether" % "aether" % aetherVersion,
     "org.eclipse.aether" % "aether-impl" % aetherVersion,
     "org.eclipse.aether" % "aether-util" % aetherVersion,
     "org.eclipse.aether" % "aether-transport-file" % aetherVersion,


### PR DESCRIPTION
sbt-maven-resolver depends on `"org.eclipse.aether" % "aether"` which is a parent pom and therfore isn't really needed as a dependency.

This results in failure of `updateSbtClassifiers` sbt task in projects using the plugin. Because sbt attempts to download nonexistent sources jar of aether.

```
[error] stack trace is suppressed; run last my-project / updateSbtClassifiers for the full output
[error] (my-project / updateSbtClassifiers) lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
[error] https://repo1.maven.org/maven2/org/eclipse/aether/aether/1.1.0/aether-1.1.0-sources.jar: not found: https://repo1.maven.org/maven2/org/eclipse/aether/aether/1.1.0/aether-1.1.0-sources.jar
[error] Total time: 0 s, completed Sep 13, 2021 4:57:03 PM
```